### PR TITLE
Few improovements on auth pages

### DIFF
--- a/src/components/account/Login.js
+++ b/src/components/account/Login.js
@@ -1,7 +1,6 @@
 import Inferno from 'inferno'
 import Component from 'inferno-component'
 import { connect } from 'inferno-mobx'
-import Loading from '../common/Loading'
 import Error from '../common/Error'
 
 @connect(['account'])
@@ -31,19 +30,18 @@ class Login extends Component {
         const { router } = this.context
         const { username, password } = this.state
 
-        account.login({ username, password })
-            .then(() => {
-                this.setState({
-                    error: null,
-                    loading: true
-                })
-                setTimeout(() => router.push('/'), 500)
-            })
+        this.setState({
+            error: null,
+            loading: true
+        })
+
+        new Promise(resolve => setTimeout(resolve, 500))
+            .then(() => account.login({ username, password }))
+            .then(() => router.push('/'))
             .catch(error => {
                 this.setState({
                     error,
                     loading: false,
-                    password: ''
                 })
             })
     }
@@ -53,12 +51,13 @@ class Login extends Component {
 
         return <main>
             <h1>sign-in</h1>
-            <form className="account" onSubmit={(e) => this.handleLogin(e)}>
+            <form className="account" onSubmit={this.handleLogin}>
                 <label>
                     Username
                     <input type="text"
                            name="username"
-                           onKeyUp={this.handleChange}
+                           required
+                           onInput={this.handleChange}
                     />
                 </label>
 
@@ -66,15 +65,17 @@ class Login extends Component {
                     Password
                     <input type="password"
                            name="password"
-                           onKeyUp={this.handleChange}/>
+                           required
+                           onInput={this.handleChange}
+                    />
                 </label>
 
-                {error && <Error text={error}/>}
-
                 {loading
-                    ? <Loading/>
-                    : <button onClick={(e) => this.handleLogin(e)}>Login</button>
+                    ? <button disabled>Loading</button>
+                    : <button type="submit">Login</button>
                 }
+
+                {error && <Error text={error}/>}
             </form>
         </main>
     }

--- a/src/components/account/Logout.js
+++ b/src/components/account/Logout.js
@@ -1,7 +1,6 @@
 import Inferno from 'inferno'
 import Component from 'inferno-component'
 import { connect } from 'inferno-mobx'
-import Loading from '../common/Loading'
 
 @connect(['account'])
 class Logout extends Component {
@@ -19,12 +18,12 @@ class Logout extends Component {
         const { account } = this.props
         const { router } = this.context
 
-        account.logout().then(() => {
-            this.setState({
-                loading: true
-            })
-            setTimeout(() => router.push('/'), 500)
+        this.setState({
+            loading: true
         })
+        new Promise(resolve => setTimeout(resolve, 500))
+            .then(() => account.logout())
+            .then(() => router.push('/'))
     }
 
     render() {
@@ -36,7 +35,7 @@ class Logout extends Component {
                 <p>This will disconnect you and you will have to login again next time.</p>
 
                 {loading
-                    ? <Loading/>
+                    ? <button disabled>Loading</button>
                     : <button onClick={this.handleLogout}>Logout</button>
                 }
             </center>


### PR DESCRIPTION
Had a few bugs while trying to Login/Registration, so I did some fixes

1. Fill values by `onInput` callback, since `onKeyUp` does not fire on autofill, mouse paste, etc
2. `Loading` seems broken, replaced by `button disabled`, 
3. Put delay before request, not after, otherwise promise catch will miss delay
4. Removed autocomplete in Chrome on Registration page by `autocomplete="new-password"`
5. Added some html5 validation with `required` attribute
6. Moved `Error` tag to the end — makes button to hold position